### PR TITLE
Make AlignedStream readinto based

### DIFF
--- a/dissect/util/stream.py
+++ b/dissect/util/stream.py
@@ -8,22 +8,27 @@ STREAM_BUFFER_SIZE = int(os.getenv("DISSECT_STREAM_BUFFER_SIZE", io.DEFAULT_BUFF
 
 
 class AlignedStream(io.RawIOBase):
-    """Basic buffered stream that provides easy aligned reads.
+    """Basic buffered stream that provides aligned reads.
 
     Must be subclassed for various stream implementations. Subclasses can implement:
-        - _read(offset, length)
-        - _seek(pos, whence=io.SEEK_SET)
+        - :meth:`~AlignedStream._read`
+        - :meth:`~AlignedStream._readinto`
+        - :meth:`~AlignedStream._seek`
 
-    The offset and length for _read are guaranteed to be aligned. The only time
+    The offset and length for ``_read`` and ``_readinto`` are guaranteed to be aligned. The only time
     that overriding _seek would make sense is if there's no known size of your stream,
-    but still want to provide SEEK_END functionality.
+    but still want to provide ``SEEK_END`` functionality.
 
-    Most subclasses of AlignedStream take one or more file-like objects as source.
+    Most subclasses of ``AlignedStream`` take one or more file-like objects as source.
     Operations on these subclasses, like reading, will modify the source file-like object as a side effect.
 
     Args:
-        size: The size of the stream. This is used in read and seek operations. None if unknown.
+        size: The size of the stream. This is used in read and seek operations. ``None`` if unknown.
         align: The alignment size. Read operations are aligned on this boundary. Also determines buffer size.
+
+    .. automethod:: _read
+    .. automethod:: _readinto
+    .. automethod:: _seek
     """
 
     def __init__(self, size: Optional[int] = None, align: int = STREAM_BUFFER_SIZE):
@@ -34,27 +39,28 @@ class AlignedStream(io.RawIOBase):
         self._pos = 0
         self._pos_align = 0
 
-        self._buf = None
-        self._seek_lock = Lock()
+        self._buf = memoryview(bytearray(align))
+        self._buf_size = 0
+        self._read_lock = Lock()
 
-    def _set_pos(self, pos: int) -> None:
-        """Update the position and aligned position within the stream."""
-        new_pos_align = pos - (pos % self.align)
+    def readable(self) -> bool:
+        """Indicate that the stream is readable."""
+        return True
 
-        if self._pos_align != new_pos_align:
-            self._pos_align = new_pos_align
-            self._buf = None
+    def seekable(self) -> bool:
+        """Indicate that the stream is seekable."""
+        return True
 
-        self._pos = pos
+    def seek(self, pos: int, whence: int = io.SEEK_SET) -> int:
+        """Seek the stream to the specified position."""
+        with self._read_lock:
+            pos = self._seek(pos, whence)
+            self._set_pos(pos)
 
-    def _fill_buf(self) -> None:
-        """Fill the alignment buffer if we can."""
-        if self._buf or self.size is not None and (self.size <= self._pos or self.size <= self._pos_align):
-            return
-
-        self._buf = self._read(self._pos_align, self.align)
+            return pos
 
     def _seek(self, pos: int, whence: int = io.SEEK_SET) -> int:
+        """Calculate and return the new stream position after a seek."""
         if whence == io.SEEK_SET:
             if pos < 0:
                 raise ValueError(f"negative seek position {pos}")
@@ -69,115 +75,172 @@ class AlignedStream(io.RawIOBase):
 
         return pos
 
-    def seek(self, pos: int, whence: int = io.SEEK_SET) -> int:
-        """Seek the stream to the specified position."""
-        with self._seek_lock:
-            pos = self._seek(pos, whence)
-            self._set_pos(pos)
+    def _set_pos(self, pos: int) -> None:
+        """Update the position and aligned position within the stream."""
+        new_pos_align = pos - (pos % self.align)
 
-            return pos
+        if self._pos_align != new_pos_align:
+            self._pos_align = new_pos_align
+            self._buf_size = 0
 
-    def read(self, n: int = -1) -> bytes:
-        """Read and return up to n bytes, or read to the end of the stream if n is -1.
+        self._pos = pos
 
-        Returns an empty bytes object on EOF.
-        """
-        if n is not None and n < -1:
-            raise ValueError("invalid number of bytes to read")
+    def tell(self) -> int:
+        """Return current stream position."""
+        return self._pos
 
-        r = []
-        size = self.size
-        align = self.align
+    def _fill_buf(self) -> None:
+        """Fill the alignment buffer if we can."""
+        if self._buf_size or self.size is not None and (self.size <= self._pos or self.size <= self._pos_align):
+            # Don't fill the buffer if:
+            # - We already have a buffer
+            # - The stream position is at the end (or beyond) the stream size
+            return
 
-        with self._seek_lock:
-            if size is None and n == -1:
-                r = []
-                if self._buf:
-                    buffer_pos = self._pos - self._pos_align
-                    r.append(self._buf[buffer_pos:])
-
-                r.append(self._read(self._pos_align + align, -1))
-
-                buf = b"".join(r)
-                self._set_pos(self._pos + len(buf))
-                return buf
-
-            if size is not None:
-                remaining = size - self._pos
-
-                if n == -1:
-                    n = remaining
-                else:
-                    n = min(n, remaining)
-
-            if n == 0 or size is not None and size <= self._pos:
-                return b""
-
-            # Read misaligned start from buffer
-            if self._pos != self._pos_align:
-                self._fill_buf()
-
-                buffer_pos = self._pos - self._pos_align
-                remaining = align - buffer_pos
-                buffer_len = min(n, remaining)
-
-                r.append(self._buf[buffer_pos : buffer_pos + buffer_len])
-
-                n -= buffer_len
-                self._set_pos(self._pos + buffer_len)
-
-            # Aligned blocks
-            if n >= align:
-                count, n = divmod(n, align)
-
-                read_len = count * align
-                r.append(self._read(self._pos, read_len))
-
-                self._set_pos(self._pos + read_len)
-
-            # Misaligned end
-            if n > 0:
-                self._fill_buf()
-                r.append(self._buf[:n])
-                self._set_pos(self._pos + n)
-
-            return b"".join(r)
+        self._buf_size = self._readinto(self._pos_align, self._buf)
 
     def readinto(self, b: bytearray) -> int:
         """Read bytes into a pre-allocated bytes-like object b.
 
         Returns an int representing the number of bytes read (0 for EOF).
         """
-        buf = self.read(len(b))
-        length = len(buf)
-        b[:length] = buf
-        return length
+        with self._read_lock:
+            return self._readinto_unlocked(b)
+
+    def _readinto_unlocked(self, b: bytearray) -> int:
+        if not isinstance(b, memoryview):
+            b = memoryview(b)
+        b = b.cast("B")
+
+        n = len(b)
+        size = self.size
+        align = self.align
+        total_read = 0
+
+        # If we know the stream size, adjust n
+        if size is not None:
+            remaining = size - self._pos
+
+            if n == -1:
+                n = remaining
+            else:
+                n = min(n, remaining)
+
+        # Short path for when it turns out we don't need to read anything
+        if n == 0 or size is not None and size <= self._pos:
+            return 0
+
+        # Read misaligned start from buffer
+        if self._pos != self._pos_align:
+            self._fill_buf()
+
+            buffer_pos = self._pos - self._pos_align
+            buffer_remaining = max(0, min(align, self._buf_size) - buffer_pos)
+            read_len = min(n, buffer_remaining)
+
+            b[:read_len] = self._buf[buffer_pos : buffer_pos + read_len]
+            b = b[read_len:]
+
+            n -= read_len
+            total_read += read_len
+            self._set_pos(self._pos + read_len)
+
+        # Aligned blocks
+        if n >= align:
+            count, n = divmod(n, align)
+
+            read_len = count * align
+            actual_read = self._readinto(self._pos, b[:read_len])
+            b = b[actual_read:]
+
+            total_read += actual_read
+            self._set_pos(self._pos + read_len)
+
+        # Misaligned remaining bytes
+        if n > 0:
+            self._fill_buf()
+
+            buffer_pos = self._pos - self._pos_align
+            buffer_remaining = max(0, min(align, self._buf_size) - buffer_pos)
+            read_len = min(n, buffer_remaining)
+
+            b[:read_len] = self._buf[:read_len]
+
+            total_read += read_len
+            self._set_pos(self._pos + read_len)
+
+        return total_read
 
     def _read(self, offset: int, length: int) -> bytes:
-        """Read method that backs this aligned stream."""
+        """Provide an aligned ``read`` implementation for this stream."""
         raise NotImplementedError("_read needs to be implemented by subclass")
+
+    def _readinto(self, offset: int, buf: memoryview) -> int:
+        """Provide an aligned ``readinto`` implementation for this stream.
+
+        For backwards compatibility, ``AlignedStream`` provides a default ``_readinto`` implementation that
+        falls back on ``_read``. However, subclasses should override this method instead of ``_read``.
+        """
+        return self._readinto_fallback(offset, buf)
+
+    def _readinto_fallback(self, offset: int, buf: bytearray) -> int:
+        """``_readinto`` fallback on ``_read``."""
+        read_len = len(buf)
+        result = self._read(offset, read_len)
+        length = len(result)
+
+        if length > read_len:
+            raise IOError(f"_read returned more bytes than requested, wanted {read_len} and returned {length}")
+
+        buf[:length] = result
+        return length
 
     def readall(self) -> bytes:
         """Read until end of stream."""
-        return self.read()
+        if self.size is not None:
+            # If we have a known stream size, we can do a more optimized read
+            return self.read(self.size - self._pos)
+
+        with self._read_lock:
+            result = bytearray()
+
+            if self._buf:
+                # Drain the buffer first
+                buffer_pos = self._pos - self._pos_align
+                buffer_remaining = max(0, min(self.align, self._buf_size) - buffer_pos)
+                result += self._buf[buffer_pos : buffer_pos + buffer_remaining]
+
+                self._set_pos(self._pos + buffer_remaining)
+
+            # Read the remaining bytes
+            try:
+                # Check if our stream implementation has a _read we can use
+                result += self._read(self._pos, -1)
+            except NotImplementedError:
+                # Otherwise call _readinto a bunch of times
+                buf = bytearray(io.DEFAULT_BUFFER_SIZE)
+
+                while n := self._readinto(self._pos, buf):
+                    result += buf[:n]
+                    self._set_pos(self._pos + n)
+
+            return bytes(result)
 
     def readoffset(self, offset: int, length: int) -> bytes:
-        """Convenience method to read from a certain offset with 1 call."""
+        """Convenience method to read from a given offset."""
         self.seek(offset)
         return self.read(length)
 
-    def tell(self) -> int:
-        """Return current stream position."""
-        return self._pos
+    def peek(self, n: int = 0) -> bytes:
+        """Convenience method to peek from the current offset without advancing the stream position."""
+        pos = self._pos
+        data = self.read(n)
+        self._set_pos(pos)
+        return data
 
     def close(self) -> None:
+        """Close the stream. Does nothing by default."""
         pass
-
-    def readable(self) -> bool:
-        return True
-
-    def seekable(self) -> bool:
-        return True
 
 
 class RangeStream(AlignedStream):
@@ -202,13 +265,29 @@ class RangeStream(AlignedStream):
         self._fh = fh
         self.offset = offset
 
+    def _seek(self, pos: int, whence: int = io.SEEK_SET) -> int:
+        if self.size is None and whence == io.SEEK_END:
+            pos = self._fh.seek(pos, whence)
+            if pos is None:
+                pos = self._fh.tell()
+            return max(0, pos - self.offset)
+        return super()._seek(pos, whence)
+
     def _read(self, offset: int, length: int) -> bytes:
-        read_length = min(length, self.size - offset)
+        # We will generally only end up here from :func:`AlignedStream.readall`
+        read_length = min(length, self.size - offset) if self.size else length
         self._fh.seek(self.offset + offset)
         return self._fh.read(read_length)
 
+    def _readinto(self, offset: int, buf: memoryview) -> int:
+        if not hasattr(self._fh, "readinto"):
+            return self._readinto_fallback(offset, buf)
 
-class RelativeStream(AlignedStream):
+        self._fh.seek(self.offset + offset)
+        return self._fh.readinto(buf)
+
+
+class RelativeStream(RangeStream):
     """Create a relative stream from another file-like object.
 
     ASCII representation::
@@ -226,22 +305,7 @@ class RelativeStream(AlignedStream):
     """
 
     def __init__(self, fh: BinaryIO, offset: int, size: Optional[int] = None, align: int = STREAM_BUFFER_SIZE):
-        super().__init__(size, align)
-        self._fh = fh
-        self.offset = offset
-
-    def _seek(self, pos: int, whence: int = io.SEEK_SET) -> int:
-        if whence == io.SEEK_END:
-            pos = self._fh.seek(pos, whence)
-            if pos is None:
-                pos = self._fh.tell()
-            return max(0, pos - self.offset)
-        return super()._seek(pos, whence)
-
-    def _read(self, offset: int, length: int) -> bytes:
-        read_length = min(length, self.size - offset) if self.size else length
-        self._fh.seek(self.offset + offset)
-        return self._fh.read(read_length)
+        super().__init__(fh, offset, size, align)
 
 
 class BufferedStream(RelativeStream):
@@ -283,7 +347,7 @@ class MappingStream(AlignedStream):
         """
         self._runs.append((offset, size, fh, file_offset))
         self._runs = sorted(self._runs)
-        self._buf = None
+        self._buf_size = 0
         self.size = self._runs[-1][0] + self._runs[-1][1]
 
     def _get_run_idx(self, offset: int) -> tuple[int, int, BinaryIO, int]:
@@ -304,19 +368,22 @@ class MappingStream(AlignedStream):
 
         raise EOFError(f"No mapping for offset {offset}")
 
-    def _read(self, offset: int, length: int) -> bytes:
-        result = []
+    def _readinto(self, offset: int, buf: memoryview) -> int:
+        size = self.size
+        runs = self._runs
 
         run_idx = self._get_run_idx(offset)
         runlist_len = len(self._runs)
-        size = self.size
+
+        n = 0
+        length = len(buf)
 
         while length > 0:
             if run_idx >= runlist_len:
                 # We somehow requested more data than we have runs for
                 break
 
-            run_offset, run_size, run_fh, run_file_offset = self._runs[run_idx]
+            run_offset, run_size, run_fh, run_file_offset = runs[run_idx]
 
             if run_offset > offset:
                 # We landed in a gap, stop reading
@@ -331,13 +398,18 @@ class MappingStream(AlignedStream):
             read_count = min(size - offset, min(run_remaining, length))
 
             run_fh.seek(run_file_offset + run_pos)
-            result.append(run_fh.read(read_count))
+            if hasattr(run_fh, "readinto"):
+                n += run_fh.readinto(buf[:read_count])
+            else:
+                buf[:read_count] = run_fh.read(read_count)
+                n += read_count
 
             offset += read_count
             length -= read_count
+            buf = buf[read_count:]
             run_idx += 1
 
-        return b"".join(result)
+        return n
 
 
 class RunlistStream(AlignedStream):
@@ -355,8 +427,15 @@ class RunlistStream(AlignedStream):
         block_size: The block size in bytes.
     """
 
-    def __init__(self, fh: BinaryIO, runlist: list[tuple[int, int]], size: int, block_size: int):
-        super().__init__(size, block_size)
+    def __init__(
+        self,
+        fh: BinaryIO,
+        runlist: list[tuple[int, int]],
+        size: int,
+        block_size: int,
+        align: Optional[int] = None,
+    ):
+        super().__init__(size, align or block_size)
 
         if isinstance(fh, RunlistStream):
             self._fh = fh._fh
@@ -368,6 +447,7 @@ class RunlistStream(AlignedStream):
 
         self.runlist = runlist
         self.block_size = block_size
+        self._has_readinto = hasattr(self._fh, "readinto")
 
     @property
     def runlist(self) -> list[tuple[int, int]]:
@@ -385,16 +465,21 @@ class RunlistStream(AlignedStream):
                 self._runlist_offsets.append(offset)
             offset += block_count
 
-        self._buf = None
+        self._buf_size = 0
 
-    def _read(self, offset: int, length: int) -> bytes:
-        r = []
+    def _readinto(self, offset: int, buf: memoryview) -> int:
+        fh = self._fh
+        size = self.size
+        runlist = self.runlist
+        runlist_offsets = self._runlist_offsets
+        block_size = self.block_size
 
         block_offset = offset // self.block_size
-
         run_idx = bisect_right(self._runlist_offsets, block_offset)
         runlist_len = len(self.runlist)
-        size = self.size
+
+        n = 0
+        length = len(buf)
 
         while length > 0:
             if run_idx >= runlist_len:
@@ -402,11 +487,11 @@ class RunlistStream(AlignedStream):
                 break
 
             # If run_idx == 0, we only have a single run
-            run_block_pos = 0 if run_idx == 0 else self._runlist_offsets[run_idx - 1]
-            run_block_offset, run_block_count = self.runlist[run_idx]
+            run_block_pos = 0 if run_idx == 0 else runlist_offsets[run_idx - 1]
+            run_block_offset, run_block_count = runlist[run_idx]
 
-            run_size = run_block_count * self.block_size
-            run_pos = offset - run_block_pos * self.block_size
+            run_size = run_block_count * block_size
+            run_pos = offset - run_block_pos * block_size
             run_remaining = run_size - run_pos
 
             # Sometimes the self.size is way larger than what we actually have runs for?
@@ -418,16 +503,22 @@ class RunlistStream(AlignedStream):
 
             # Sparse run
             if run_block_offset is None:
-                r.append(b"\x00" * read_count)
+                buf[:read_count] = b"\x00" * read_count
+                n += read_count
             else:
-                self._fh.seek(run_block_offset * self.block_size + run_pos)
-                r.append(self._fh.read(read_count))
+                fh.seek(run_block_offset * block_size + run_pos)
+                if self._has_readinto:
+                    n += fh.readinto(buf[:read_count])
+                else:
+                    buf[:read_count] = fh.read(read_count)
+                    n += read_count
 
             offset += read_count
             length -= read_count
+            buf = buf[read_count:]
             run_idx += 1
 
-        return b"".join(r)
+        return n
 
 
 class OverlayStream(AlignedStream):
@@ -447,6 +538,7 @@ class OverlayStream(AlignedStream):
         self._fh = fh
         self.overlays: dict[int, tuple[int, BinaryIO]] = {}
         self._lookup: list[int] = []
+        self._has_readinto = hasattr(self._fh, "readinto")
 
     def add(self, offset: int, data: Union[bytes, BinaryIO], size: Optional[int] = None) -> None:
         """Add an overlay at the given offset.
@@ -478,20 +570,21 @@ class OverlayStream(AlignedStream):
         self._lookup.sort()
 
         # Clear the buffer if we add an overlay at our current position
-        if self._buf and (self._pos_align <= offset + size and offset <= self._pos_align + len(self._buf)):
-            self._buf = None
+        if self._buf_size and (self._pos_align <= offset + size and offset <= self._pos_align + self.align):
+            self._buf_size = 0
 
         return self
 
-    def _read(self, offset: int, length: int) -> bytes:
-        result = []
-
+    def _readinto(self, offset: int, buf: memoryview) -> int:
         fh = self._fh
         overlays = self.overlays
         lookup = self._lookup
 
         overlay_len = len(overlays)
         overlay_idx = bisect_left(lookup, offset)
+
+        n = 0
+        length = len(buf)
 
         while length > 0:
             prev_overlay_offset = None if overlay_idx == 0 else lookup[overlay_idx - 1]
@@ -508,10 +601,12 @@ class OverlayStream(AlignedStream):
                     prev_overlay_read_size = min(length, prev_overlay_remaining)
 
                     prev_overlay_data.seek(offset_in_prev_overlay)
-                    result.append(prev_overlay_data.read(prev_overlay_read_size))
+                    buf[:prev_overlay_read_size] = prev_overlay_data.read(prev_overlay_read_size)
+                    n += prev_overlay_read_size
 
                     offset += prev_overlay_read_size
                     length -= prev_overlay_read_size
+                    buf = buf[prev_overlay_read_size:]
 
             if length == 0:
                 break
@@ -523,26 +618,41 @@ class OverlayStream(AlignedStream):
                 if 0 <= gap_to_next_overlay < length:
                     if gap_to_next_overlay:
                         fh.seek(offset)
-                        result.append(fh.read(gap_to_next_overlay))
+                        if self._has_readinto:
+                            n += fh.readinto(buf[:gap_to_next_overlay])
+                        else:
+                            buf[:gap_to_next_overlay] = fh.read(gap_to_next_overlay)
+                            n += gap_to_next_overlay
+                        buf = buf[gap_to_next_overlay:]
 
                     # read remaining from overlay
                     next_overlay_read_size = min(next_overlay_size, length - gap_to_next_overlay)
                     next_overlay_data.seek(0)
-                    result.append(next_overlay_data.read(next_overlay_read_size))
+                    buf[:next_overlay_read_size] = next_overlay_data.read(next_overlay_read_size)
+                    n += next_overlay_read_size
 
                     offset += next_overlay_read_size + gap_to_next_overlay
                     length -= next_overlay_read_size + gap_to_next_overlay
+                    buf = buf[next_overlay_read_size + gap_to_next_overlay :]
                 else:
                     # Next overlay is too far away, complete read
                     fh.seek(offset)
-                    result.append(fh.read(length))
+                    if self._has_readinto:
+                        n += fh.readinto(buf[:length])
+                    else:
+                        buf[:length] = fh.read(length)
+                        n += length
                     break
             else:
                 # No next overlay, complete read
                 fh.seek(offset)
-                result.append(fh.read(length))
+                if self._has_readinto:
+                    n += fh.readinto(buf[:length])
+                else:
+                    buf[:length] = fh.read(length)
+                    n += length
                 break
 
             overlay_idx += 1
 
-        return b"".join(result)
+        return n

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,11 +1,12 @@
 import io
+from unittest.mock import Mock
 
 import pytest
 
 from dissect.util import stream
 
 
-def test_range_stream():
+def test_range_stream() -> None:
     buf = io.BytesIO(b"\x01" * 10 + b"\x02" * 10 + b"\x03" * 10)
     fh = stream.RangeStream(buf, 5, 15)
 
@@ -39,7 +40,7 @@ def test_range_stream():
     assert fh.tell() == 0
 
 
-def test_relative_stream():
+def test_relative_stream() -> None:
     buf = io.BytesIO(b"\x01" * 10 + b"\x02" * 10 + b"\x03" * 10)
     fh = stream.RelativeStream(buf, 5)
 
@@ -59,17 +60,18 @@ def test_relative_stream():
     assert fh.read(1) == b""
 
 
-def test_buffered_stream():
+def test_buffered_stream() -> None:
     buf = io.BytesIO(b"\x01" * 512 + b"\x02" * 512 + b"\x03" * 512)
     fh = stream.BufferedStream(buf, size=None)
 
     assert fh.read(10) == b"\x01" * 10
-    assert fh._buf == buf.getvalue()
+    assert fh._buf[: len(buf.getvalue())] == buf.getvalue()
+    assert fh._buf_size == 512 * 3
     assert fh.read() == buf.getvalue()[10:]
     assert fh.read(1) == b""
 
 
-def test_mapping_stream():
+def test_mapping_stream() -> None:
     buffers = [
         io.BytesIO(b"\x01" * 512),
         io.BytesIO(b"\x02" * 512),
@@ -90,7 +92,7 @@ def test_mapping_stream():
     assert fh.read(1) == b""
 
 
-def test_runlist_stream():
+def test_runlist_stream() -> None:
     buf = io.BytesIO(b"\x01" * 512 + b"\x02" * 512 + b"\x03" * 512)
     fh = stream.RunlistStream(buf, [(0, 32), (32, 16), (48, 48)], 1536, 16)
 
@@ -106,7 +108,7 @@ def test_runlist_stream():
     assert fh.read(1) == b""
 
 
-def test_aligned_stream_buffer():
+def test_aligned_stream_buffer() -> None:
     buf = io.BytesIO(b"\x01" * 512 + b"\x02" * 512 + b"\x03" * 512 + b"\x04" * 512)
     fh = stream.RelativeStream(buf, 0, align=512)
 
@@ -118,13 +120,13 @@ def test_aligned_stream_buffer():
     # Read aligned blocks so we move past the offset from where the buffer was read
     fh.read(1024)
     # Buffer should be reset
-    assert fh._buf is None
+    assert fh._buf_size == 0
     # Buffer should now be from the 3rd aligned block
     assert fh.read(256) == b"\x03" * 256
     assert fh._buf == b"\x03" * 512
 
 
-def test_overlay_stream():
+def test_overlay_stream() -> None:
     buf = io.BytesIO(b"\x00" * 512 * 8)
     fh = stream.OverlayStream(buf, size=512 * 8, align=512)
 
@@ -166,3 +168,17 @@ def test_overlay_stream():
     fh.add((512 * 8) - 4, b"\x04" * 100)
     fh.seek((512 * 8) - 4)
     assert fh.read(100) == b"\x04" * 4
+
+
+def test_layered_readinto() -> None:
+    size = 1024 * 64
+    buf = io.BytesIO(b"\x42" * size)
+    mock_buffer = Mock(wraps=buf)
+
+    fh = stream.BufferedStream(stream.BufferedStream(mock_buffer, 0, size), 0, size)
+    tmp = bytearray(1024)
+    fh.readinto(tmp)
+
+    # Test the bottom layer buffer was called with the cache object of the top layer
+    mock_buffer.readinto.assert_called_once()
+    assert mock_buffer.readinto.call_args[0][0].obj is fh._buf.obj


### PR DESCRIPTION
Mostly experimental for now and requires benchmarking and profiling to see it it's worth pursuing this further. In some initial tests this turns out to be slower, but that's probably also because the rest of the chain (all containers and Dissect implementations) will use the `_read` fallback.