### PR TITLE
ts: Make dostimestamp() fall back to epoch on parse failures

### DIFF
--- a/dissect/util/ts.py
+++ b/dissect/util/ts.py
@@ -275,7 +275,12 @@ def dostimestamp(ts: int, centiseconds: int = 0, swap: bool = False) -> datetime
     # extra_seconds will be at most 1.
     extra_seconds, centiseconds = divmod(centiseconds, 100)
     microseconds = centiseconds * 10000
-    timestamp = datetime(year, month, day, hours, minutes, seconds + extra_seconds, microseconds)
+
+    try:
+        timestamp = datetime(year, month, day, hours, minutes, seconds + extra_seconds, microseconds)
+    except ValueError:
+        # If we fail to parse, fall back to the DOS epoch
+        timestamp = datetime(DOS_EPOCH_YEAR, 1, 1)
 
     return timestamp
 


### PR DESCRIPTION
If we detect corrupt timestamp data, fall back to the DOS epoch instead of passing on the ValueError raised by datetime(), which would stop the parsing run all together.