### PR TITLE
Add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# Formatting commits. You can ignore them during git-blame with `--ignore-rev` or `--ignore-revs-file`.
+#
+#   $ git config --add 'blame.ignoreRevsFile' '.git-blame-ignore-revs'
+#
+
+# Change linter to Ruff (#52)
+6288ce3e594c8c3d3e2280145a46dc8c1d4371c3


### PR DESCRIPTION
This file can be used to ignore certain commits when using `git blame`. Added the commit where we changed to Ruff.