### PR TITLE
Fix read_sid for empty buffers

### DIFF
--- a/dissect/util/sid.py
+++ b/dissect/util/sid.py
@@ -28,10 +28,8 @@ def read_sid(fh: BinaryIO | bytes, endian: str = "<", swap_last: bool = False) -
     if isinstance(fh, bytes):
         fh = io.BytesIO(fh)
 
-    buf = fh.read(8)
-
-    if len(buf) != 8:
-        return None
+    if len(buf := fh.read(8)) != 8:
+        return ""
 
     revision = buf[0]
     sub_authority_count = buf[1]

--- a/dissect/util/sid.py
+++ b/dissect/util/sid.py
@@ -29,6 +29,10 @@ def read_sid(fh: BinaryIO | bytes, endian: str = "<", swap_last: bool = False) -
         fh = io.BytesIO(fh)
 
     buf = fh.read(8)
+
+    if len(buf) != 8:
+        return None
+
     revision = buf[0]
     sub_authority_count = buf[1]
     authority = int.from_bytes(buf[2:], "big")

--- a/tests/test_sid.py
+++ b/tests/test_sid.py
@@ -15,8 +15,14 @@ def id_fn(val: bytes | str) -> str:
     if isinstance(val, str):
         return val
 
+    if val == b"":
+        return "empty-value"
+
     if isinstance(val, bytes):
         return val.hex()
+
+    if val is None:
+        return "None"
 
     return ""
 
@@ -65,6 +71,12 @@ def id_fn(val: bytes | str) -> str:
             "S-1-5-21-123456789-268435456-500",
             ">",
             True,
+        ),
+        (
+            b"",
+            None,
+            "<",
+            False,
         ),
     ],
     ids=id_fn,

--- a/tests/test_sid.py
+++ b/tests/test_sid.py
@@ -74,7 +74,7 @@ def id_fn(val: bytes | str) -> str:
         ),
         (
             b"",
-            None,
+            "",
             "<",
             False,
         ),


### PR DESCRIPTION
This PR fixes `read_sid` when it encounters empty buffers. Currently the function breaks if it is provided an empty buffer. Please let us know if the desired behaviour is to throw an exception or log message instead.