### PR TITLE
Add type checking

### DIFF
--- a/dissect/util/compression/__init__.py
+++ b/dissect/util/compression/__init__.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from dissect.util.compression import lz4 as lz4_python
 from dissect.util.compression import lzo as lzo_python
 
@@ -16,8 +18,8 @@ from dissect.util.compression import lzo as lzo_python
 # Note that the pure Python implementation is not a full replacement of the
 # native lz4 Python package: only the decompress() function is implemented.
 try:
-    import lz4.block as lz4
-    import lz4.block as lz4_native
+    import lz4.block as lz4  # type: ignore
+    import lz4.block as lz4_native  # type: ignore
 except ImportError:
     lz4 = lz4_python
     lz4_native = None
@@ -37,11 +39,18 @@ except ImportError:
 # Note that the pure Python implementation is not a full replacement of the
 # native lzo Python package: only the decompress() function is implemented.
 try:
-    import lzo
-    import lzo as lzo_native
+    import lzo  # type: ignore
+    import lzo as lzo_native  # type: ignore
 except ImportError:
     lzo = lzo_python
     lzo_native = None
+
+
+from dissect.util.compression import lznt1, lzxpress, lzxpress_huffman, sevenbit
+
+if TYPE_CHECKING:
+    lzo = lzo_python
+    lz4 = lz4_python
 
 __all__ = [
     "lz4",

--- a/dissect/util/compression/lznt1.py
+++ b/dissect/util/compression/lznt1.py
@@ -25,7 +25,7 @@ SIZE_MASK = (1 << 12) - 1
 TAG_MASKS = [(1 << i) for i in range(8)]
 
 
-def decompress(src: bytes | BinaryIO) -> bytes:
+def decompress(src: bytes | bytearray | memoryview | BinaryIO) -> bytes:
     """LZNT1 decompress from a file-like object or bytes.
 
     Args:
@@ -34,7 +34,7 @@ def decompress(src: bytes | BinaryIO) -> bytes:
     Returns:
         The decompressed data.
     """
-    if not hasattr(src, "read"):
+    if isinstance(src, (bytes, bytearray, memoryview)):
         src = io.BytesIO(src)
 
     offset = src.tell()

--- a/dissect/util/compression/lzo.py
+++ b/dissect/util/compression/lzo.py
@@ -23,7 +23,7 @@ def _read_length(src: BinaryIO, val: int, mask: int) -> int:
     return length + mask + val
 
 
-def decompress(src: bytes | BinaryIO, header: bool = True, buflen: int = -1) -> bytes:
+def decompress(src: bytes | bytearray | memoryview | BinaryIO, header: bool = True, buflen: int = -1) -> bytes:
     """LZO decompress from a file-like object or bytes. Assumes no header.
 
     Arguments are largely compatible with python-lzo API.
@@ -36,7 +36,7 @@ def decompress(src: bytes | BinaryIO, header: bool = True, buflen: int = -1) -> 
     Returns:
         The decompressed data.
     """
-    if not hasattr(src, "read"):
+    if isinstance(src, (bytes, bytearray, memoryview)):
         src = io.BytesIO(src)
 
     dst = bytearray()

--- a/dissect/util/compression/lzxpress.py
+++ b/dissect/util/compression/lzxpress.py
@@ -6,7 +6,7 @@ import struct
 from typing import BinaryIO
 
 
-def decompress(src: bytes | BinaryIO) -> bytes:
+def decompress(src: bytes | bytearray | memoryview | BinaryIO) -> bytes:
     """LZXPRESS decompress from a file-like object or bytes.
 
     Args:
@@ -15,7 +15,7 @@ def decompress(src: bytes | BinaryIO) -> bytes:
     Returns:
         The decompressed data.
     """
-    if not hasattr(src, "read"):
+    if isinstance(src, (bytes, bytearray, memoryview)):
         src = io.BytesIO(src)
 
     offset = src.tell()
@@ -41,7 +41,7 @@ def decompress(src: bytes | BinaryIO) -> bytes:
             if src.tell() - offset == size:
                 break
 
-            match = struct.unpack("<H", src.read(2))[0]
+            match: int = struct.unpack("<H", src.read(2))[0]
             match_offset, match_length = divmod(match, 8)
             match_offset += 1
 

--- a/dissect/util/compression/sevenbit.py
+++ b/dissect/util/compression/sevenbit.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from io import BytesIO
+import io
 from typing import BinaryIO
 
 
-def compress(src: bytes | BinaryIO) -> bytes:
+def compress(src: bytes | bytearray | memoryview | BinaryIO) -> bytes:
     """Sevenbit compress from a file-like object or bytes.
 
     Args:
@@ -13,8 +13,8 @@ def compress(src: bytes | BinaryIO) -> bytes:
     Returns:
         The compressed data.
     """
-    if not hasattr(src, "read"):
-        src = BytesIO(src)
+    if isinstance(src, (bytes, bytearray, memoryview)):
+        src = io.BytesIO(src)
 
     dst = bytearray()
 
@@ -39,7 +39,7 @@ def compress(src: bytes | BinaryIO) -> bytes:
     return bytes(dst)
 
 
-def decompress(src: bytes | BinaryIO, wide: bool = False) -> bytes:
+def decompress(src: bytes | bytearray | memoryview | BinaryIO, wide: bool = False) -> bytes:
     """Sevenbit decompress from a file-like object or bytes.
 
     Args:
@@ -48,8 +48,8 @@ def decompress(src: bytes | BinaryIO, wide: bool = False) -> bytes:
     Returns:
         The decompressed data.
     """
-    if not hasattr(src, "read"):
-        src = BytesIO(src)
+    if isinstance(src, (bytes, bytearray, memoryview)):
+        src = io.BytesIO(src)
 
     dst = bytearray()
 

--- a/dissect/util/compression/xz.py
+++ b/dissect/util/compression/xz.py
@@ -8,7 +8,7 @@ HEADER_FOOTER_SIZE = 12
 CRC_SIZE = 4
 
 
-def repair_checksum(fh: BinaryIO) -> BinaryIO:
+def repair_checksum(fh: BinaryIO) -> OverlayStream:
     """Repair CRC32 checksums for all headers in an XZ stream.
 
     FortiOS XZ files have (on purpose) corrupt streams which they read using a modified ``xz`` binary.
@@ -55,7 +55,7 @@ def repair_checksum(fh: BinaryIO) -> BinaryIO:
     # Parse the index
     isize, num_records = _mbi(index[1:])
     index = index[1 + isize : -4]
-    records = []
+    records: list[tuple[int, int]] = []
     for _ in range(num_records):
         if not index:
             raise ValueError("Missing index size")

--- a/dissect/util/encoding/surrogateescape.py
+++ b/dissect/util/encoding/surrogateescape.py
@@ -5,7 +5,7 @@ def error_handler(error: Exception) -> tuple[str, int]:
     if not isinstance(error, UnicodeDecodeError):
         raise error
 
-    result = []
+    result: list[str] = []
     for i in range(error.start, error.end):
         byte = error.object[i]
         if byte < 128:

--- a/dissect/util/feature.py
+++ b/dissect/util/feature.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 import os
 from enum import Enum
-from typing import Callable, NoReturn
+from typing import Any, Callable, NoReturn
 
 
 # Register feature flags in a central place to avoid chaos
@@ -45,7 +45,7 @@ def feature_enabled(feature: Feature) -> bool:
     return feature in feature_flags()
 
 
-def feature(flag: Feature, alternative: Callable | None = None) -> Callable:
+def feature(flag: Feature | str, alternative: Callable[..., Any] | None = None) -> Callable[..., Any]:
     """Feature flag decorator allowing you to guard a function behind a feature flag.
 
     Usage::
@@ -59,7 +59,7 @@ def feature(flag: Feature, alternative: Callable | None = None) -> Callable:
 
     if alternative is None:
 
-        def alternative() -> NoReturn:
+        def default_alternative() -> NoReturn:
             raise FeatureException(
                 "\n".join(
                     [
@@ -70,7 +70,9 @@ def feature(flag: Feature, alternative: Callable | None = None) -> Callable:
                 )
             )
 
-    def decorator(func: Callable) -> Callable:
+        alternative = default_alternative
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         return func if feature_enabled(flag) else alternative
 
     return decorator

--- a/dissect/util/plist.py
+++ b/dissect/util/plist.py
@@ -3,40 +3,130 @@ from __future__ import annotations
 import plistlib
 import uuid
 from collections import UserDict
-from typing import TYPE_CHECKING, Any, BinaryIO
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, BinaryIO, Callable, TypedDict, Union, cast
 
 from dissect.util.ts import cocoatimestamp
 
 if TYPE_CHECKING:
-    from datetime import datetime
+    from collections.abc import Iterable
+
+
+_Value = Union[
+    bool,
+    bytes,
+    int,
+    float,
+    str,
+    datetime,
+    uuid.UUID,
+    "NSDictionary",
+    "NSObject",
+    "_NSClass",
+    list["_Value"],
+    dict[str, "_Value"],
+    None,
+]
+
+
+_NSKeyedArchiver = TypedDict(
+    "_NSKeyedArchiver",
+    {
+        "$version": int,
+        "$archiver": str,
+        "$top": dict[str, plistlib.UID],
+        "$objects": list["_Value | _NSObject"],
+    },
+)
+_NSClass = TypedDict(
+    "_NSClass",
+    {
+        "$classname": str,
+        "$classes": list[str],
+    },
+)
+_NSObject = TypedDict(
+    "_NSObject",
+    {
+        "$class": plistlib.UID,
+    },
+)
+_NSArray = TypedDict(
+    "_NSArray",
+    {
+        "$class": plistlib.UID,
+        "NS.objects": list[_Value | plistlib.UID],
+    },
+)
+_NSMutableArray = _NSMutableSet = _NSSet = _NSArray
+_NSDictionary = TypedDict(
+    "_NSDictionary",
+    {
+        "$class": plistlib.UID,
+        "NS.keys": list[plistlib.UID],
+        "NS.objects": list[plistlib.UID],
+    },
+)
+_NSMutableDictionary = _NSDictionary
+_NSData = TypedDict(
+    "_NSData",
+    {
+        "$class": plistlib.UID,
+        "NS.data": bytes,
+    },
+)
+_NSMutableData = _NSData
+_NSDate = TypedDict(
+    "_NSDate",
+    {
+        "$class": plistlib.UID,
+        "NS.time": int,
+    },
+)
+_NSUUID = TypedDict(
+    "_NSUUID",
+    {
+        "$class": plistlib.UID,
+        "NS.uuidbytes": bytes,
+    },
+)
+_NSURL = TypedDict(
+    "_NSURL",
+    {
+        "$class": plistlib.UID,
+        "NS.base": plistlib.UID,
+        "NS.relative": plistlib.UID,
+    },
+)
 
 
 class NSKeyedArchiver:
     def __init__(self, fh: BinaryIO):
-        self.plist = plistlib.load(fh)
+        plist: Any = plistlib.load(fh)
 
-        if not isinstance(self.plist, dict) or not all(
-            key in self.plist for key in ["$version", "$archiver", "$top", "$objects"]
+        if not isinstance(plist, dict) or not all(
+            key in plist for key in ["$version", "$archiver", "$top", "$objects"]
         ):
             raise ValueError("File is not an NSKeyedArchiver plist")
 
-        self._objects = self.plist.get("$objects")
-        self._cache = {}
+        self.plist: _NSKeyedArchiver = cast(_NSKeyedArchiver, plist)
+        self._objects = self.plist.get("$objects", [])
+        self._cache: dict[int, _Value] = {}
 
-        self.top = {}
+        self.top: dict[str, _Value] = {}
         for name, value in self.plist.get("$top", {}).items():
             self.top[name] = self._parse(value)
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> _Value:
         return self.top[key]
 
     def __repr__(self) -> str:
         return f"<NSKeyedArchiver top={self.top}>"
 
-    def get(self, key: str, default: Any | None = None) -> Any:
+    def get(self, key: str, default: _Value | None = None) -> _Value:
         return self.top.get(key, default)
 
-    def _parse(self, uid: Any) -> Any:
+    def _parse(self, uid: _Value | plistlib.UID) -> _Value:
         if not isinstance(uid, plistlib.UID):
             return uid
 
@@ -47,13 +137,12 @@ class NSKeyedArchiver:
         self._cache[num] = result
         return result
 
-    def _parse_obj(self, obj: Any) -> Any:
+    def _parse_obj(self, obj: _Value | _NSObject) -> _Value:
         if isinstance(obj, dict):
-            klass = obj.get("$class")
-            if klass:
-                klass_name = self._parse(klass).get("$classname")
+            if klass := obj.get("$class"):
+                klass_name = cast(_NSClass, self._parse(klass)).get("$classname")
                 return CLASSES.get(klass_name, NSObject)(self, obj)
-            return obj
+            return cast(dict[Any, Any], obj)
 
         if isinstance(obj, list):
             return list(map(self._parse, obj))
@@ -68,79 +157,78 @@ class NSKeyedArchiver:
 
 
 class NSObject:
-    def __init__(self, nskeyed: NSKeyedArchiver, obj: dict[str, Any]):
+    def __init__(self, nskeyed: NSKeyedArchiver, obj: _NSObject):
         self.nskeyed = nskeyed
         self.obj = obj
 
-        self._class = nskeyed._parse(obj.get("$class", {}))
+        self._class: _NSClass = cast(_NSClass, nskeyed._parse(obj.get("$class", {})))
         self._classname = self._class.get("$classname", "Unknown")
         self._classes = self._class.get("$classes", [])
 
-    def __getitem__(self, attr: str) -> Any:
-        obj = self.obj[attr]
-        return self.nskeyed._parse(obj)
+    def __getitem__(self, attr: str) -> _Value:
+        return self.nskeyed._parse(cast(_Value, self.obj[attr]))
 
-    def __getattr__(self, attr: str) -> Any:
+    def __getattr__(self, attr: str) -> _Value:
         try:
             return self[attr]
         except KeyError:
             raise AttributeError(attr)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<{self._classname}>"
 
-    def keys(self) -> list[str]:
+    def keys(self) -> Iterable[str]:
         return self.obj.keys()
 
-    def get(self, attr: str, default: Any | None = None) -> Any:
+    def get(self, attr: str, default: object | None = None) -> object | None:
         try:
             return self[attr]
         except KeyError:
             return default
 
 
-class NSDictionary(UserDict, NSObject):
-    def __init__(self, nskeyed: NSKeyedArchiver, obj: dict[str, Any]):
+class NSDictionary(UserDict, NSObject):  # type: ignore
+    def __init__(self, nskeyed: NSKeyedArchiver, obj: _NSDictionary):
         NSObject.__init__(self, nskeyed, obj)
-        self.data = {nskeyed._parse(key): obj for key, obj in zip(obj["NS.keys"], obj["NS.objects"])}
+        self.data: dict[_Value, Any] = {nskeyed._parse(key): obj for key, obj in zip(obj["NS.keys"], obj["NS.objects"])}
 
     def __repr__(self) -> str:
         return NSObject.__repr__(self)
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> _Value:
         return self.nskeyed._parse(self.data[key])
 
 
-def parse_nsarray(nskeyed: NSKeyedArchiver, obj: dict[str, Any]) -> list[Any]:
+def parse_nsarray(nskeyed: NSKeyedArchiver, obj: _NSArray | _NSMutableArray) -> list[_Value]:
     return list(map(nskeyed._parse, obj["NS.objects"]))
 
 
-def parse_nsset(nskeyed: NSKeyedArchiver, obj: dict[str, Any]) -> list[Any]:
+def parse_nsset(nskeyed: NSKeyedArchiver, obj: _NSSet | _NSMutableSet) -> list[_Value]:
     # Some values are not hashable, so return as list
     return parse_nsarray(nskeyed, obj)
 
 
-def parse_nsdata(nskeyed: NSKeyedArchiver, obj: dict[str, Any]) -> Any:
+def parse_nsdata(nskeyed: NSKeyedArchiver, obj: _NSData) -> bytes:
     return obj["NS.data"]
 
 
-def parse_nsdate(nskeyed: NSKeyedArchiver, obj: dict[str, Any]) -> datetime:
+def parse_nsdate(nskeyed: NSKeyedArchiver, obj: _NSDate) -> datetime:
     return cocoatimestamp(obj["NS.time"])
 
 
-def parse_nsuuid(nskeyed: NSKeyedArchiver, obj: dict[str, Any]) -> uuid.UUID:
+def parse_nsuuid(nskeyed: NSKeyedArchiver, obj: _NSUUID) -> uuid.UUID:
     return uuid.UUID(bytes=obj["NS.uuidbytes"])
 
 
-def parse_nsurl(nskeyed: NSKeyedArchiver, obj: dict[str, Any]) -> str:
-    base = nskeyed._parse(obj["NS.base"])
-    relative = nskeyed._parse(obj["NS.relative"])
+def parse_nsurl(nskeyed: NSKeyedArchiver, obj: _NSURL) -> str:
+    base = cast(str, nskeyed._parse(obj["NS.base"]))
+    relative = cast(str, nskeyed._parse(obj["NS.relative"]))
     if base:
         return f"{base}/{relative}"
     return relative
 
 
-CLASSES = {
+CLASSES: dict[str, Callable[[NSKeyedArchiver, Any], _Value]] = {
     "NSArray": parse_nsarray,
     "NSMutableArray": parse_nsarray,
     "NSDictionary": NSDictionary,

--- a/dissect/util/tools/dump_nskeyedarchiver.py
+++ b/dissect/util/tools/dump_nskeyedarchiver.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import argparse
-from typing import Any
+from typing import Any, cast
 
 from dissect.util.plist import NSKeyedArchiver, NSObject
 
@@ -15,13 +15,13 @@ def main() -> None:
         try:
             obj = NSKeyedArchiver(fh)
         except ValueError as e:
-            parser.exit(str(e))
+            parser.exit(1, str(e))
 
         print(obj)
         print_object(obj.top)
 
 
-def print_object(obj: Any, indent: int = 0, seen: set | None = None) -> None:
+def print_object(obj: Any, indent: int = 0, seen: set[Any] | None = None) -> None:
     if seen is None:
         seen = set()
 
@@ -33,7 +33,7 @@ def print_object(obj: Any, indent: int = 0, seen: set | None = None) -> None:
         pass
 
     if isinstance(obj, list):
-        for i, v in enumerate(obj):
+        for i, v in enumerate(cast(list[Any], obj)):
             print(fmt(f"[{i}]:", indent))
             print_object(v, indent + 1, seen)
 
@@ -45,7 +45,7 @@ def print_object(obj: Any, indent: int = 0, seen: set | None = None) -> None:
             except TypeError:
                 pass
 
-        for k in sorted(obj.keys()):
+        for k in sorted(cast(dict[Any, Any], obj).keys()):
             print(fmt(f"{k}:", indent + 1))
             print_object(obj[k], indent + 2, seen)
 

--- a/dissect/util/ts.py
+++ b/dissect/util/ts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import struct
 import sys
 from datetime import datetime, timedelta, timezone, tzinfo
+from typing import TypedDict
 
 if sys.platform in ("win32", "emscripten"):
     _EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
@@ -288,6 +289,11 @@ def dostimestamp(ts: int, centiseconds: int = 0, swap: bool = False) -> datetime
     )
 
 
+class _TZInfo(TypedDict):
+    name: str
+    offset: int
+
+
 class UTC(tzinfo):
     """tzinfo class for timezones that have a fixed-offset from UTC
 
@@ -295,17 +301,17 @@ class UTC(tzinfo):
         tz_dict: Dictionary of ``{"name": "timezone name", "offset": offset_from_UTC_in_minutes}``
     """
 
-    def __init__(self, tz_dict: dict[str, str | int]):
+    def __init__(self, tz_dict: _TZInfo):
         # offset should be in minutes
         self.name = tz_dict["name"]
         self.offset = timedelta(minutes=tz_dict["offset"])
 
-    def utcoffset(self, dt: datetime) -> timedelta:
+    def utcoffset(self, dt: datetime | None) -> timedelta:
         return self.offset
 
-    def tzname(self, dt: datetime) -> str:
+    def tzname(self, dt: datetime | None) -> str:
         return self.name
 
-    def dst(self, dt: datetime) -> timedelta:
+    def dst(self, dt: datetime | None) -> timedelta:
         # do not account for daylight saving
         return timedelta(0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,12 @@ lz4 = [
 [project.scripts]
 dump-nskeyedarchiver = "dissect.util.tools.dump_nskeyedarchiver:main"
 
+[tool.pyright]
+pythonVersion = "3.9"
+pythonPlatform = "All"
+typeCheckingMode = "strict"
+reportPrivateUsage = false
+
 [tool.ruff]
 line-length = 120
 required-version = ">=0.9.0"

--- a/tests/test_cpio.py
+++ b/tests/test_cpio.py
@@ -20,13 +20,15 @@ def _verify_archive(archive: TarFile) -> None:
     assert small_file.name == "small-file"
     assert small_file.size == 9
     assert small_file.isfile()
-    assert archive.extractfile(small_file).read() == b"contents\n"
+    assert (fh := archive.extractfile(small_file))
+    assert fh.read() == b"contents\n"
 
     large_file = archive.getmember("large-file")
     assert large_file.name == "large-file"
     assert large_file.size == 0x3FC000
     assert small_file.isfile()
-    assert archive.extractfile(large_file).read() == b"".join([bytes([i] * 4096) for i in range(255)]) * 4
+    assert (fh := archive.extractfile(large_file))
+    assert fh.read() == b"".join([bytes([i] * 4096) for i in range(255)]) * 4
 
     symlink_1 = archive.getmember("symlink-1")
     assert symlink_1.issym()

--- a/tests/test_plist.py
+++ b/tests/test_plist.py
@@ -2,11 +2,13 @@ import datetime
 import plistlib
 import sys
 import uuid
+from io import BytesIO
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
 
-from dissect.util.plist import NSKeyedArchiver
+from dissect.util.plist import NSKeyedArchiver, NSObject
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
@@ -132,10 +134,10 @@ def test_plist_nskeyedarchiver() -> None:
         ],
     }
     with patch("plistlib.load", return_value=data):
-        obj = NSKeyedArchiver(None)
+        obj = NSKeyedArchiver(BytesIO(b""))
         assert "root" in obj.top
 
-        root = obj["root"]
+        root = cast(NSObject, obj["root"])
         assert root._classname == "TestObject"
         assert root.Null is None
         assert root.Integer == 1337
@@ -147,4 +149,4 @@ def test_plist_nskeyedarchiver() -> None:
         assert root.URL == "http://base/relative"
         assert root.URLBaseless == "relative"
         assert root.Array == root.Set == [1, "TestString"]
-        assert list(root.Dict.items()) == [("DictKey", "TestString")]
+        assert list(cast(dict[Any, Any], root.Dict).items()) == [("DictKey", "TestString")]

--- a/tests/test_sid.py
+++ b/tests/test_sid.py
@@ -8,7 +8,7 @@ import pytest
 from dissect.util import sid
 
 
-def id_fn(val: bytes | str) -> str:
+def id_fn(val: bytes | str | None) -> str:
     if isinstance(val, io.BytesIO):
         val = val.getvalue()
 

--- a/tox.ini
+++ b/tox.ini
@@ -38,11 +38,12 @@ commands =
 [testenv:lint]
 package = skip
 deps =
+    pytest  # For the typing
+    pyright[nodejs]
     ruff==0.9.2
-    vermin
 commands =
+    pyright dissect tests
     ruff check dissect tests
-    vermin -t=3.9- --no-tips --lint dissect tests
 
 [testenv:docs-build]
 allowlist_externals = make


### PR DESCRIPTION
Closes #68 

I've chosen to use `pyright` because it appears to be the current most advanced type checking tool available for Python. I've set this project to use `strict` type checking, but other settings are `basic` and `standard`. For most other Dissect projects, I think we should just start out with `basic` and incrementally increase it.

The side-effect of type checking in the `lint` step are that we now must also install dependencies in order to check types with that.

I've given it my best shot to make `dissect.util` adhere to the `strict` ruleset.