### PR TITLE
Remove unused UTC class

### DIFF
--- a/dissect/util/ts.py
+++ b/dissect/util/ts.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import struct
 import sys
-from datetime import datetime, timedelta, timezone, tzinfo
+from datetime import datetime, timedelta, timezone
 
 if sys.platform in ("win32", "emscripten"):
     _EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
@@ -287,26 +287,3 @@ def dostimestamp(ts: int, centiseconds: int = 0, swap: bool = False) -> datetime
         seconds + extra_seconds,
         microseconds,
     )
-
-
-class UTC(tzinfo):
-    """tzinfo class for timezones that have a fixed-offset from UTC
-
-    Args:
-        tz_dict: Dictionary of ``{"name": "timezone name", "offset": offset_from_UTC_in_minutes}``
-    """
-
-    def __init__(self, tz_dict: dict[str, str | int]):
-        # offset should be in minutes
-        self.name = tz_dict["name"]
-        self.offset = timedelta(minutes=tz_dict["offset"])
-
-    def utcoffset(self, dt: datetime) -> timedelta:
-        return self.offset
-
-    def tzname(self, dt: datetime) -> str:
-        return self.name
-
-    def dst(self, dt: datetime) -> timedelta:
-        # do not account for daylight saving
-        return timedelta(0)

--- a/dissect/util/ts.py
+++ b/dissect/util/ts.py
@@ -240,10 +240,10 @@ DOS_EPOCH_YEAR = 1980
 def dostimestamp(ts: int, centiseconds: int = 0, swap: bool = False) -> datetime:
     """Converts MS-DOS timestamps to naive datetime objects.
 
-    MS-DOS timestamps are recorded in local time, so we leave it up to the
-    caller to add optional timezone information.
+    MS-DOS timestamps are recorded in local time, so we leave it up to the caller to add optional timezone information.
 
-    According to http://www.vsft.com/hal/dostime.htm
+    References:
+        - https://web.archive.org/web/20180311003959/http://www.vsft.com/hal/dostime.htm
 
     Args:
         ts: MS-DOS timestamp
@@ -280,8 +280,8 @@ def dostimestamp(ts: int, centiseconds: int = 0, swap: bool = False) -> datetime
 
     return datetime(  # noqa: DTZ001
         year,
-        month,
-        day,
+        month or 1,
+        day or 1,
         hours,
         minutes,
         seconds + extra_seconds,

--- a/tests/test_ts.py
+++ b/tests/test_ts.py
@@ -134,6 +134,11 @@ def test_cocoatimestamp(imported_ts: ModuleType) -> None:
     assert imported_ts.cocoatimestamp(622894123.221783) == datetime(2020, 9, 27, 10, 8, 43, 221783, tzinfo=timezone.utc)
 
 
+def test_dostimestamp(imported_ts: ModuleType) -> None:
+    assert imported_ts.dostimestamp(1391424892, 3) == datetime(2021, 7, 15, 14, 43, 56, 30000)  # noqa: DTZ001
+    assert imported_ts.dostimestamp(0) == datetime(1980, 1, 1, 0, 0)  # noqa: DTZ001
+
+
 def test_negative_timestamps(imported_ts: ModuleType) -> None:
     # -5000.0 converted to a int representation
     assert imported_ts.oatimestamp(13885591609694748672) == datetime(1886, 4, 22, 0, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
This class is only used by exFAT code in `dissect.target`. It doesn't belong in this repo.