### PR TITLE
Add write support to foreign endian xmemoryviews

### DIFF
--- a/dissect/util/xmemoryview.py
+++ b/dissect/util/xmemoryview.py
@@ -68,9 +68,9 @@ class _xmemoryview:  # noqa: N801
         self._struct_to = struct.Struct(format)
 
     def tolist(self) -> list[int]:
-        return self._convert(self._view.tolist())
+        return self._convert_from_native(self._view.tolist())
 
-    def _convert(self, value: list[int] | int) -> int:
+    def _convert_from_native(self, value: list[int] | int) -> int:
         if isinstance(value, list):
             endian = self._format[0]
             fmt = self._format[1]
@@ -78,18 +78,28 @@ class _xmemoryview:  # noqa: N801
             return list(struct.unpack(f"{endian}{pck}", struct.pack(f"={pck}", *value)))
         return self._struct_to.unpack(self._struct_frm.pack(value))[0]
 
+    def _convert_to_native(self, value: list[int] | int) -> int:
+        if isinstance(value, list):
+            endian = self._format[0]
+            fmt = self._format[1]
+            pck = f"{len(value)}{fmt}"
+            return list(struct.unpack(f"={pck}", struct.pack(f"{endian}{pck}", *value)))
+        return self._struct_frm.unpack(self._struct_to.pack(value))[0]
+
     def __getitem__(self, idx: int | slice) -> int | bytes:
         value = self._view[idx]
         if isinstance(idx, int):
-            return self._convert(value)
+            return self._convert_from_native(value)
         if isinstance(idx, slice):
             return _xmemoryview(self._view[idx], self._format)
 
         raise TypeError("Invalid index type")
 
-    def __setitem__(self, *args, **kwargs) -> None:
-        # setitem looks like it's a no-op on cast memoryviews?
-        pass
+    def __setitem__(self, idx: int | slice, value: list[int] | int) -> None:
+        if isinstance(idx, (int, slice)):
+            self._view[idx] = self._convert_to_native(value)
+        else:
+            raise TypeError("Invalid index type")
 
     def __len__(self) -> int:
         return len(self._view)
@@ -101,7 +111,7 @@ class _xmemoryview:  # noqa: N801
 
     def __iter__(self) -> Iterator[int]:
         for value in self._view:
-            yield self._convert(value)
+            yield self._convert_from_native(value)
 
     def __getattr__(self, attr: str) -> Any:
         return getattr(self._view, attr)

--- a/tests/test_xmemoryview.py
+++ b/tests/test_xmemoryview.py
@@ -16,6 +16,12 @@ def test_xmemoryview_little() -> None:
     assert xview[:4].tobytes() == b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f"
     assert xview[0:5].tolist() == [0x03020100, 0x07060504, 0x0B0A0908, 0x0F0E0D0C, 0x13121110]
 
+    xview[0] = 0x12345678
+    assert xview[0] == 0x12345678
+    assert buf[:4] == b"\x78\x56\x34\x12"
+    xview[0] = 0x03020100
+    # Setting a slice is not actually supported by memoryview, so don't test it
+
     it = iter(xview)
     assert list(it)[:5] == [0x03020100, 0x07060504, 0x0B0A0908, 0x0F0E0D0C, 0x13121110]
 
@@ -32,6 +38,12 @@ def test_xmemoryview_big() -> None:
     assert xview[:4].tobytes() == b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f"
     assert xview[0:5].tolist() == [0x00010203, 0x04050607, 0x08090A0B, 0x0C0D0E0F, 0x10111213]
     assert xview[0:10] == xview[0:10]
+
+    xview[0] = 0x12345678
+    assert xview[0] == 0x12345678
+    assert buf[:4] == b"\x12\x34\x56\x78"
+    xview[0] = 0x00010203
+    # Setting a slice is not actually supported by memoryview, so don't test it
 
     it = iter(xview)
     assert list(it)[:5] == [0x00010203, 0x04050607, 0x08090A0B, 0x0C0D0E0F, 0x10111213]


### PR DESCRIPTION
`xmemoryview` did not yet support writing for foreign endianness, this adds support for it.