### PR TITLE
Add write_sid function

### DIFF
--- a/dissect/util/sid.py
+++ b/dissect/util/sid.py
@@ -50,24 +50,24 @@ def read_sid(fh: BinaryIO | bytes, endian: str = "<", swap_last: bool = False) -
     return "-".join(sid_elements)
 
 
-def write_sid(sid_str: str, endian: str = "<", swap_last: bool = False) -> bytes:
-    """Write a Windows SID string to its binary representation.
+def write_sid(sid: str, endian: str = "<", swap_last: bool = False) -> bytes:
+    """Write a Windows SID string to bytes.
 
     Args:
-        sid_str: SID in the form "S-Revision-Authority-SubAuth1-...".
+        sid: SID in the form ``S-Revision-Authority-SubAuth1-...``.
         endian: Optional endianness for reading the sub authorities.
         swap_last: Optional flag for swapping the endianess of the _last_ sub authority entry.
     """
-    if not sid_str:
+    if not sid:
         return b""
 
-    parts = sid_str.split("-")
+    parts = sid.split("-")
     if len(parts) < 3 or parts[0].upper() != "S":
-        return b""
+        raise ValueError("Invalid SID string format: insufficient parts")
 
     revision = int(parts[1]).to_bytes(1, "little")
     authority = int(parts[2]).to_bytes(6, "big")
-    sub_authorities = [int(x) for x in parts[3:]] if len(parts) > 3 else []
+    sub_authorities = [int(x) for x in parts[3:]]
 
     header = revision + len(sub_authorities).to_bytes(1, "little") + authority
 
@@ -77,4 +77,5 @@ def write_sid(sid_str: str, endian: str = "<", swap_last: bool = False) -> bytes
     sub_bytes = bytearray(struct.pack(f"{endian}{len(sub_authorities)}I", *sub_authorities))
     if swap_last:
         sub_bytes[-4:] = sub_bytes[-4:][::-1]
+
     return header + bytes(sub_bytes)

--- a/tests/test_sid.py
+++ b/tests/test_sid.py
@@ -84,8 +84,12 @@ def id_fn(val: bytes | str) -> str:
     ],
     ids=id_fn,
 )
-def test_read_sid(binary_sid: bytes | BinaryIO, endian: str, swap_last: bool, readable_sid: str) -> None:
+def test_read_write_sid(binary_sid: bytes | BinaryIO, endian: str, swap_last: bool, readable_sid: str) -> None:
     assert readable_sid == sid.read_sid(binary_sid, endian, swap_last)
+
+    if isinstance(binary_sid, io.BytesIO):
+        binary_sid = binary_sid.getvalue()
+    assert binary_sid == sid.write_sid(readable_sid, endian, swap_last)
 
 
 @pytest.mark.benchmark
@@ -105,66 +109,6 @@ def test_read_sid(binary_sid: bytes | BinaryIO, endian: str, swap_last: bool, re
 )
 def test_read_sid_benchmark(benchmark: BenchmarkFixture, binary_sid: bytes, swap_last: bool) -> None:
     benchmark(sid.read_sid, binary_sid, "<", swap_last)
-
-
-@pytest.mark.parametrize(
-    ("binary_sid", "readable_sid", "endian", "swap_last"),
-    [
-        (
-            b"\x01\x00\x00\x00\x00\x00\x00\x00",
-            "S-1-0",
-            "<",
-            False,
-        ),
-        (
-            b"\x01\x01\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00",
-            "S-1-1-0",
-            "<",
-            False,
-        ),
-        (
-            b"\x01\x04\x00\x00\x00\x00\x00\x05\x15\x00\x00\x00\x15\xcd\x5b\x07\x00\x00\x00\x10\xf4\x01\x00\x00",
-            "S-1-5-21-123456789-268435456-500",
-            "<",
-            False,
-        ),
-        (
-            io.BytesIO(b"\x01\x01\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00"),
-            "S-1-1-0",
-            "<",
-            False,
-        ),
-        (
-            b"\x01\x04\x00\x00\x00\x00\x00\x05\x00\x00\x00\x15\x07\x5b\xcd\x15\x10\x00\x00\x00\x00\x00\x01\xf4",
-            "S-1-5-21-123456789-268435456-500",
-            ">",
-            False,
-        ),
-        (
-            b"\x01\x04\x00\x00\x00\x00\x00\x05\x15\x00\x00\x00\x15\xcd\x5b\x07\x00\x00\x00\x10\x00\x00\x01\xf4",
-            "S-1-5-21-123456789-268435456-500",
-            "<",
-            True,
-        ),
-        (
-            b"\x01\x04\x00\x00\x00\x00\x00\x05\x00\x00\x00\x15\x07\x5b\xcd\x15\x10\x00\x00\x00\xf4\x01\x00\x00",
-            "S-1-5-21-123456789-268435456-500",
-            ">",
-            True,
-        ),
-        (
-            b"",
-            "",
-            "<",
-            False,
-        ),
-    ],
-    ids=id_fn,
-)
-def test_write_sid(readable_sid: str, endian: str, swap_last: bool, binary_sid: bytes) -> None:
-    if isinstance(binary_sid, io.BytesIO):
-        binary_sid = binary_sid.getvalue()
-    assert binary_sid == sid.write_sid(readable_sid, endian, swap_last)
 
 
 @pytest.mark.benchmark


### PR DESCRIPTION
Add the `write_sid` function, basically the inverse of `read_sid`. Used in the NTDS parser, and may be of use in the future for other projects.