### PR TITLE
Add ADC decompression

### DIFF
--- a/dissect/util/compression/adc.py
+++ b/dissect/util/compression/adc.py
@@ -40,7 +40,10 @@ def decompress(src: bytes | BinaryIO) -> bytes:
         if distance > len(dst):
             raise ValueError("Invalid match distance in ADC stream")
 
-        for _ in range(count):
-            dst.append(dst[-distance])
+        remaining = count
+        while remaining > 0:
+            match_size = min(remaining, distance)
+            dst += dst[-distance : (-distance + match_size) or None]
+            remaining -= match_size
 
     return bytes(dst)

--- a/dissect/util/compression/adc.py
+++ b/dissect/util/compression/adc.py
@@ -2,6 +2,7 @@
 # - https://github.com/Lekensteyn/dmg2img/blob/develop/adc.c
 from __future__ import annotations
 
+import io
 from typing import BinaryIO
 
 
@@ -14,29 +15,27 @@ def decompress(src: bytes | BinaryIO) -> bytes:
     Returns:
         The decompressed data.
     """
-    if hasattr(src, "read"):
-        src = src.read()
+    if not hasattr(src, "read"):
+        src = io.BytesIO(src)
 
     dst = bytearray()
-    pos = 0
 
-    while pos < len(src):
-        byte = src[pos]
+    while _byte := src.read(1):
+        byte = _byte[0]
 
         if byte & 0x80:
             count = (byte & 0x7F) + 1
-            dst += src[pos + 1 : pos + 1 + count]
-            pos += 1 + count
+            dst.extend(src.read(count))
             continue
 
         if byte & 0x40:
             count = (byte & 0x3F) + 4
-            distance = (src[pos + 1] << 8) + src[pos + 2] + 1
-            pos += 3
+            extra = src.read(2)
+            distance = (extra[0] << 8) + extra[1] + 1
         else:
             count = ((byte & 0x3F) >> 2) + 3
-            distance = ((byte & 0x03) << 8) + src[pos + 1] + 1
-            pos += 2
+            extra = src.read(1)
+            distance = ((byte & 0x03) << 8) + extra[0] + 1
 
         if distance > len(dst):
             raise ValueError("Invalid match distance in ADC stream")

--- a/dissect/util/compression/adc.py
+++ b/dissect/util/compression/adc.py
@@ -1,0 +1,47 @@
+# References:
+# - https://github.com/Lekensteyn/dmg2img/blob/develop/adc.c
+from __future__ import annotations
+
+from typing import BinaryIO
+
+
+def decompress(src: bytes | BinaryIO) -> bytes:
+    """ADC (Apple Data Compression) decompress from a file-like object or bytes.
+
+    Args:
+        src: File-like object or bytes to decompress.
+
+    Returns:
+        The decompressed data.
+    """
+    if hasattr(src, "read"):
+        src = src.read()
+
+    dst = bytearray()
+    pos = 0
+
+    while pos < len(src):
+        byte = src[pos]
+
+        if byte & 0x80:
+            count = (byte & 0x7F) + 1
+            dst += src[pos + 1 : pos + 1 + count]
+            pos += 1 + count
+            continue
+
+        if byte & 0x40:
+            count = (byte & 0x3F) + 4
+            distance = (src[pos + 1] << 8) + src[pos + 2] + 1
+            pos += 3
+        else:
+            count = ((byte & 0x3F) >> 2) + 3
+            distance = ((byte & 0x03) << 8) + src[pos + 1] + 1
+            pos += 2
+
+        if distance > len(dst):
+            raise ValueError("Invalid match distance in ADC stream")
+
+        for _ in range(count):
+            dst.append(dst[-distance])
+
+    return bytes(dst)

--- a/dissect/util/compression/adc.py
+++ b/dissect/util/compression/adc.py
@@ -40,10 +40,7 @@ def decompress(src: bytes | BinaryIO) -> bytes:
         if distance > len(dst):
             raise ValueError("Invalid match distance in ADC stream")
 
-        remaining = count
-        while remaining > 0:
-            match_size = min(remaining, distance)
-            dst += dst[-distance : (-distance + match_size) or None]
-            remaining -= match_size
+        for _ in range(count):
+            dst.append(dst[-distance])
 
     return bytes(dst)

--- a/tests/compression/test_adc.py
+++ b/tests/compression/test_adc.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import hashlib
-import io
 from typing import TYPE_CHECKING
 
 import pytest
@@ -11,21 +10,45 @@ from dissect.util.compression import adc
 if TYPE_CHECKING:
     from pytest_benchmark.fixture import BenchmarkFixture
 
-DISSECT_ADC_COMPRESSION = "984469737365637420414443206465636f6d7072657373696f6e"
-DISSECT_ADC_COMPRESSION_X4 ="994469737365637420414443206465636f6d7072657373696f6e207f00192019"
 
 PARAMS = (
     ("data", "digest"),
     [
         pytest.param(
-            DISSECT_ADC_COMPRESSION,
-            "c46e20738514d290b73b16759320908f22fdb174c54b9eed36191617a55e9bc9",
-            id="literal",
+            "80007f00007f00007f00007f00007f00007f000068001683feffffee00038001004a814d206e004f8155aa",
+            "8f07c1fe1f936f1c90594be4773789af3f1c0bc5f117396d17641cb0c11992cc",
+            id="basic",
         ),
         pytest.param(
-            DISSECT_ADC_COMPRESSION_X4,
-            "d79ef73f9dff01059f5ea46434768492dd9eb39d2a83fe282a9ba86b35f6acfa",
-            id="matches",
+            "a1ef57347c0000aa11aa1100306543ecacc720e4affaef7f4689d11236f2"
+            "63affc28000c008127201008100f886400690073006b00200007866d0061"
+            "006700652c207f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00007f00007f00007f00007f00007f0000"
+            "7f00007f00007f00007f00007f00004a3fc7",
+            "74faa5da44da54516026fe33c0e4a0eca261f02ea01bc1434143d77007ee57b1",
+            id="large",
         ),
     ],
 )
@@ -34,25 +57,6 @@ PARAMS = (
 @pytest.mark.parametrize(*PARAMS)
 def test_adc_decompress(data: str, digest: str) -> None:
     assert hashlib.sha256(adc.decompress(bytes.fromhex(data))).hexdigest() == digest
-
-
-@pytest.mark.parametrize(*PARAMS)
-def test_adc_decompress_stream(data: str, digest: str) -> None:
-    assert hashlib.sha256(adc.decompress(io.BytesIO(bytes.fromhex(data)))).hexdigest() == digest
-
-
-def test_adc_decompress_plaintext() -> None:
-    assert adc.decompress(bytes.fromhex(DISSECT_ADC_COMPRESSION)) == (
-        b"Dissect ADC decompression"
-    )
-    assert adc.decompress(bytes.fromhex(DISSECT_ADC_COMPRESSION_X4)) == (
-        b"Dissect ADC decompression " * 4
-    )
-
-
-def test_adc_decompress_invalid_distance() -> None:
-    with pytest.raises(ValueError, match="Invalid match distance in ADC stream"):
-        adc.decompress(bytes.fromhex("0000"))
 
 
 @pytest.mark.benchmark

--- a/tests/compression/test_adc.py
+++ b/tests/compression/test_adc.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import hashlib
+import io
+from typing import TYPE_CHECKING
+
+import pytest
+
+from dissect.util.compression import adc
+
+if TYPE_CHECKING:
+    from pytest_benchmark.fixture import BenchmarkFixture
+
+DISSECT_ADC_COMPRESSION = "984469737365637420414443206465636f6d7072657373696f6e"
+DISSECT_ADC_COMPRESSION_X4 ="994469737365637420414443206465636f6d7072657373696f6e207f00192019"
+
+PARAMS = (
+    ("data", "digest"),
+    [
+        pytest.param(
+            DISSECT_ADC_COMPRESSION,
+            "c46e20738514d290b73b16759320908f22fdb174c54b9eed36191617a55e9bc9",
+            id="literal",
+        ),
+        pytest.param(
+            DISSECT_ADC_COMPRESSION_X4,
+            "d79ef73f9dff01059f5ea46434768492dd9eb39d2a83fe282a9ba86b35f6acfa",
+            id="matches",
+        ),
+    ],
+)
+
+
+@pytest.mark.parametrize(*PARAMS)
+def test_adc_decompress(data: str, digest: str) -> None:
+    assert hashlib.sha256(adc.decompress(bytes.fromhex(data))).hexdigest() == digest
+
+
+@pytest.mark.parametrize(*PARAMS)
+def test_adc_decompress_stream(data: str, digest: str) -> None:
+    assert hashlib.sha256(adc.decompress(io.BytesIO(bytes.fromhex(data)))).hexdigest() == digest
+
+
+def test_adc_decompress_plaintext() -> None:
+    assert adc.decompress(bytes.fromhex(DISSECT_ADC_COMPRESSION)) == (
+        b"Dissect ADC decompression"
+    )
+    assert adc.decompress(bytes.fromhex(DISSECT_ADC_COMPRESSION_X4)) == (
+        b"Dissect ADC decompression " * 4
+    )
+
+
+def test_adc_decompress_invalid_distance() -> None:
+    with pytest.raises(ValueError, match="Invalid match distance in ADC stream"):
+        adc.decompress(bytes.fromhex("0000"))
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize(*PARAMS)
+def test_benchmark_adc_decompress(data: str, digest: str, benchmark: BenchmarkFixture) -> None:
+    assert hashlib.sha256(benchmark(adc.decompress, bytes.fromhex(data))).hexdigest() == digest


### PR DESCRIPTION
Add support for ADC (Apple Data Compression) decompression. Though it is no longer commonly used, it is still a supported compression method in a DMG file.